### PR TITLE
Add optionnal parameter 'target'

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Extra command to invoke before ansible-test **(OPTIONAL)**
 Controller Python version **(DEFAULT: `3.9`)**
 
 
+### `target`
+
+ansible-test TARGET **(OPTIONAL)**
+
+
 ### `target-python-version`
 
 Target Python version **(OPTIONAL)**

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Controller Python version **(DEFAULT: `3.9`)**
 
 ### `target`
 
-ansible-test TARGET **(OPTIONAL)**
+`ansible-test` TARGET **(OPTIONAL)**
 
 
 ### `target-python-version`

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   python-version:
     description: Controller Python version
     default: 3.9
+  target:
+    description: ansible-test TARGET
+    default:
   target-python-version:
     description: Target Python version
     default:
@@ -252,6 +255,7 @@ runs:
           && format('--python {0}', inputs.target-python-version)
           || ''
       }}
+      ${{ inputs.target }}
       ;
       set +x
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -255,6 +255,7 @@ runs:
           && format('--python {0}', inputs.target-python-version)
           || ''
       }}
+      --
       ${{ inputs.target }}
       ;
       set +x


### PR DESCRIPTION
Allows to run only one integration test instead of all of them.

Resolves https://github.com/ansible-community/ansible-test-gh-action/issues/8