### PR TITLE
Add controller-python-version parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ To use the action add the following step to your workflow file (e.g.
     pre-test-cmd: echo This runs before the ansible-test invocation
     python-version: 3.9
     target-python-version: 3.9
+    controller-python-version: auto
     testing-type: integration
     test-deps: ansible.netcommon
 - name: Perform sanity testing with ansible-test
@@ -61,6 +62,13 @@ ideas. The repository this refers to can be changed with the
 
 The GitHub repository slug from which to check out ansible-core
 **(DEFAULT: `ansible/ansible`)**
+
+
+### `controller-python-version`
+
+Controller Python version. This is only used for integration tests and
+ansible-core 2.12 or later when `target-python-version` is also specified
+**(DEFAULT: `auto`)**
 
 
 ### `collection-root`

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,12 @@ inputs:
   ansible-core-github-repository-slug:
     description: The GitHub repository slug from which to check out ansible-core
     default: ansible/ansible
+  controller-python-version:
+    description: >-
+      Controller Python version. Only used for integration tests and
+      ansible-core 2.12 or later when `target-python-version` is also
+      specified.
+    default:
   collection-root:
     description: Collection root relative to repository root
     default: .
@@ -26,7 +32,7 @@ inputs:
       A pre-checked out collection directory that's already on disk,
       substitutes getting the source from the remote Git repository if
       set. This action will not attempt to mutate its contents
-    default:
+    default: auto
   docker-image:
     description: Docker image used by ansible-test
     default:
@@ -266,7 +272,6 @@ runs:
       ;
       ~/.local/bin/ansible-test ${{ inputs.testing-type }}
       -v --color
-      --docker ${{ inputs.docker-image }}
       --coverage
       ${{
           inputs.testing-type == 'integration'
@@ -274,9 +279,23 @@ runs:
           || ''
       }}
       ${{
-          inputs.target-python-version
-          && format('--python {0}', inputs.target-python-version)
-          || ''
+          inputs.testing-type == 'integration'
+          && inputs.ansible-core-version != 'stable-2.9'
+          && inputs.ansible-core-version != 'stable-2.10'
+          && inputs.ansible-core-version != 'stable-2.11'
+          && inputs.target-python-version
+          && inputs.controller-python-version != 'auto'
+          && inputs.controller-python-version != inputs.target-python-version
+          && format('--controller docker:default,python={0} --target docker:{1},python={2}',
+                    inputs.controller-python-version,
+                    inputs.docker-image || 'default',
+                    inputs.target-python-version)
+          || inputs.target-python-version
+          && format('--docker {0} --python {1}',
+                    inputs.docker-image,
+                    inputs.target-python-version)
+          || format('--docker {0}',
+                    inputs.docker-image)
       }}
       ${{ inputs.target }}
       ;


### PR DESCRIPTION
Allows to configure the controller Python version for integration tests. Only works when the target Python version is also specified, and ansible-core 2.12 or later is used.