### PR TITLE
Treat `collection-root` input of `'.'` as CWD

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -17,11 +17,15 @@ jobs:
       matrix:
         ansible-core-version:
         -
+        collection-root:
+        -
         collection-src-directory:
         -
         docker-image:
         - default
         git-checkout-ref:
+        -
+        pre-action-cmd:
         -
         pre-test-cmd:
         -
@@ -38,19 +42,31 @@ jobs:
         exclude:
         - ansible-core-version:
         include:
+        - ansible-core-version: stable-2.11
+          python-version: '3.6'
+          testing-type: sanity
+          collection-root: .
+          collection-src-directory: ./.tmp-action-checkout
+          pre-action-cmd: >-
+            mv -v .internal/ansible/ansible_collections/internal/test/galaxy.yml .
+          pre-test-cmd: rm -rfv .internal/
         - ansible-core-version: stable-2.12
+          collection-root: .internal/ansible/ansible_collections/internal/test
           collection-src-directory: ./.tmp-action-checkout
           python-version: '3.8'
           testing-type: sanity
         - ansible-core-version: devel
+          collection-root: .internal/ansible/ansible_collections/internal/test
           collection-src-directory: ./.tmp-action-checkout
           python-version: '3.9'
           testing-type: units
         - ansible-core-version: stable-2.13
+          collection-root: .internal/ansible/ansible_collections/internal/test
           collection-src-directory: ./.tmp-action-checkout
           python-version: '3.10'
           testing-type: integration
         - ansible-core-version: stable-2.13
+          collection-root: .internal/ansible/ansible_collections/internal/test
           # NOTE: A missing `collection-src-directory` input causes
           # NOTE: fetching the repo from GitHub.
           python-version: '3.10'
@@ -61,12 +77,17 @@ jobs:
       with:
         path: .tmp-action-checkout/
 
+    - name: Run a pre-action command
+      if: matrix.pre-action-cmd
+      run: ${{ matrix.pre-action-cmd }}
+      working-directory: ./.tmp-action-checkout/
+
     - name: Run ${{ matrix.testing-type }} tests
       uses: ./.tmp-action-checkout/
       with:
         ansible-core-version: ${{ matrix.ansible-core-version }}
+        collection-root: ${{ matrix.collection-root }}
         collection-src-directory: ${{ matrix.collection-src-directory }}
-        collection-root: .internal/ansible/ansible_collections/internal/test
         docker-image: ${{ matrix.docker-image }}
         git-checkout-ref: ${{ matrix.git-checkout-ref }}
         pre-test-cmd: ${{ matrix.pre-test-cmd }}

--- a/action.yml
+++ b/action.yml
@@ -207,7 +207,7 @@ runs:
             && inputs.collection-src-directory
             || '.tmp-ansible-collection-checkout'
           ),
-          inputs.collection-root
+          inputs.collection-root != '.' && inputs.collection-root || ''
         )
       }}"
       "${{ steps.collection-metadata.outputs.checkout-path }}"


### PR DESCRIPTION
Currently the action does not work with its default value for `collection-root` since it tries to `mv -v .tmp-ansible-collection-checkout/. ansible_collections/community/xxx`, which results in `Device or resource busy`. The trailing dot must not be there.

This breaks this action, see https://github.com/ansible-collections/community.hrobot/runs/7739502850?check_suite_focus=true and https://github.com/ansible-collections/community.dns/runs/7739442963?check_suite_focus=true for example.

This PR should hopefully fix it.

Unfortunately the tests do not show this since the repository root for the included collection does not use the default path...

Closes #26.