### PR TITLE
Add a `git-checkout-repository` action input

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -58,6 +58,7 @@ jobs:
         collection-root: .internal/ansible/ansible_collections/internal/test
         docker-image: ${{ matrix.docker-image }}
         git-checkout-ref: ${{ matrix.git-checkout-ref }}
+        git-checkout-repository: ./.tmp-action-checkout/.git
         pre-test-cmd: ${{ matrix.pre-test-cmd }}
         python-version: ${{ matrix.python-version }}
         target: ${{ matrix.target }}

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -58,7 +58,7 @@ jobs:
         collection-root: .internal/ansible/ansible_collections/internal/test
         docker-image: ${{ matrix.docker-image }}
         git-checkout-ref: ${{ matrix.git-checkout-ref }}
-        git-checkout-repository: ./.tmp-action-checkout/.git
+        # git-checkout-repository: ./.tmp-action-checkout/.git
         pre-test-cmd: ${{ matrix.pre-test-cmd }}
         python-version: ${{ matrix.python-version }}
         target: ${{ matrix.target }}

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Path to collection root relative to repository root **(DEFAULT: `.`)**
 A container image spawned by `ansible-test` **(OPTIONAL)**
 
 
+### `git-checkout-repository`
+
+A Git repository to check out **(OPTIONAL; if unset or empty,
+the default fallback selection is deferred to `actions/checkout`)**
+
+
 ### `pre-test-cmd`
 
 Extra command to invoke before ansible-test **(OPTIONAL)**

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ inputs:
   git-checkout-ref:
     description: Committish to check out
     default:
+  git-checkout-repository:
+    description: A Git repository to check out
+    default:
   pre-test-cmd:
     description: Extra command to invoke before ansible-test
     default:
@@ -114,6 +117,7 @@ runs:
       path: .tmp-ansible-collection-checkout
       persist-credentials: false
       ref: ${{ inputs.git-checkout-ref }}
+      repository: ${{ inputs.git-checkout-repository }}
   - name: Close an expandable block of code
     run: >-
       echo ::endgroup::

--- a/action.yml
+++ b/action.yml
@@ -174,7 +174,7 @@ runs:
       mkdir -pv
       "${{ steps.collection-metadata.outputs.collection-namespace-path }}"
       ;
-      ln -s
+      mv -v
       ".tmp-ansible-collection-checkout/${{ inputs.collection-root }}"
       "${{ steps.collection-metadata.outputs.checkout-path }}"
       ;

--- a/action.yml
+++ b/action.yml
@@ -174,7 +174,7 @@ runs:
       mkdir -pv
       "${{ steps.collection-metadata.outputs.collection-namespace-path }}"
       ;
-      mv -v
+      ln -s
       ".tmp-ansible-collection-checkout/${{ inputs.collection-root }}"
       "${{ steps.collection-metadata.outputs.checkout-path }}"
       ;


### PR DESCRIPTION
This input allows changing the target tested collection repository, if
set. If it isn't, the upstream action `actions/checkout` will use its
internal logic to determine the target repository to fetch.