### PR TITLE
Add a `collection-src-directory` action input

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -17,6 +17,8 @@ jobs:
       matrix:
         ansible-core-version:
         -
+        collection-src-directory:
+        -
         docker-image:
         - default
         git-checkout-ref:
@@ -37,12 +39,20 @@ jobs:
         - ansible-core-version:
         include:
         - ansible-core-version: stable-2.12
+          collection-src-directory: ./.tmp-action-checkout
           python-version: '3.8'
           testing-type: sanity
         - ansible-core-version: devel
+          collection-src-directory: ./.tmp-action-checkout
           python-version: '3.9'
           testing-type: units
         - ansible-core-version: stable-2.13
+          collection-src-directory: ./.tmp-action-checkout
+          python-version: '3.10'
+          testing-type: integration
+        - ansible-core-version: stable-2.13
+          # NOTE: A missing `collection-src-directory` input causes
+          # NOTE: fetching the repo from GitHub.
           python-version: '3.10'
           testing-type: integration
     steps:
@@ -55,6 +65,7 @@ jobs:
       uses: ./.tmp-action-checkout/
       with:
         ansible-core-version: ${{ matrix.ansible-core-version }}
+        collection-src-directory: ${{ matrix.collection-src-directory }}
         collection-root: .internal/ansible/ansible_collections/internal/test
         docker-image: ${{ matrix.docker-image }}
         git-checkout-ref: ${{ matrix.git-checkout-ref }}

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ The GitHub repository slug from which to check out ansible-core
 Path to collection root relative to repository root **(DEFAULT: `.`)**
 
 
+### `collection-src-directory`
+
+A pre-checked out collection directory that's already on disk
+**(OPTIONAL, substitutes getting the source from the remote Git
+repository if set, also this action will not attempt to mutate
+its contents)**
+
+
 ### `docker-image`
 
 A container image spawned by `ansible-test` **(OPTIONAL)**

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,12 @@ inputs:
   ansible-core-github-repository-slug:
     description: The GitHub repository slug from which to check out ansible-core
     default: ansible/ansible
+  collection-src-directory:
+    description: >-
+      A pre-checked out collection directory that's already on disk,
+      substitutes getting the source from the remote Git repository if
+      set. This action will not attempt to mutate its contents
+    default:
   collection-root:
     description: Collection root relative to repository root
     default: .
@@ -25,7 +31,9 @@ inputs:
     description: Docker image used by ansible-test
     default:
   git-checkout-ref:
-    description: Committish to check out
+    description: >-
+      Committish to check out, unused
+      if `collection-src-directory` is set
     default:
   pre-test-cmd:
     description: Extra command to invoke before ansible-test
@@ -105,16 +113,22 @@ runs:
     shell: bash
 
   - name: Open an expandable block of code
+    if: >-
+      !inputs.collection-src-directory
     run: >-
       echo ::group::Checking out the repository into a temporary location...
     shell: bash
   - name: Check out the collection
+    if: >-
+      !inputs.collection-src-directory
     uses: actions/checkout@v3
     with:
       path: .tmp-ansible-collection-checkout
       persist-credentials: false
       ref: ${{ inputs.git-checkout-ref }}
   - name: Close an expandable block of code
+    if: >-
+      !inputs.collection-src-directory
     run: >-
       echo ::endgroup::
     shell: bash
@@ -152,7 +166,18 @@ runs:
           format(name=coll_name, ns=coll_ns)
       )
     shell: python
-    working-directory: .tmp-ansible-collection-checkout/${{ inputs.collection-root }}
+    working-directory: >-
+      ${{
+        format(
+          '{0}/{1}',
+          (
+            inputs.collection-src-directory
+            && inputs.collection-src-directory
+            || '.tmp-ansible-collection-checkout'
+          ),
+          inputs.collection-root
+        )
+      }}
   - name: Close an expandable block of code
     run: >-
       echo ::endgroup::
@@ -160,18 +185,31 @@ runs:
 
   - name: Open an expandable block of code
     run: >-
-      echo ::group::Move "'${{ steps.collection-metadata.outputs.fqcn }}'"
+      echo ::group::${{
+        inputs.collection-src-directory && 'Copy' || 'Move'
+      }} "'${{ steps.collection-metadata.outputs.fqcn }}'"
       collection to ${{ steps.collection-metadata.outputs.checkout-path }}...
     shell: bash
-  - name: Install ansible-core (${{ inputs.ansible-core-version }})
+  - name: Move the collection to the proper path
     run: >-
       set -x
       ;
       mkdir -pv
       "${{ steps.collection-metadata.outputs.collection-namespace-path }}"
       ;
-      mv -v
-      ".tmp-ansible-collection-checkout/${{ inputs.collection-root }}"
+      ${{ inputs.collection-src-directory && 'cp -a' || 'mv' }}
+      -v
+      "${{
+        format(
+          '{0}/{1}',
+          (
+            inputs.collection-src-directory
+            && inputs.collection-src-directory
+            || '.tmp-ansible-collection-checkout'
+          ),
+          inputs.collection-root
+        )
+      }}"
       "${{ steps.collection-metadata.outputs.checkout-path }}"
       ;
       set +x


### PR DESCRIPTION
This input allows running the action against a project directory that
has been checked out and prepared prior to invoking it.