### PR TITLE
Allow to use ansible-test's change detection for Pull Requests

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -36,6 +36,8 @@ jobs:
         - ''
         pre-test-cmd:
         - ''
+        pull-request-change-detection:
+        - ''
         target:
         - ''
         target-python-version:
@@ -70,6 +72,7 @@ jobs:
           collection-root: .internal/ansible/ansible_collections/internal/test
           collection-src-directory: ./.tmp-action-checkout
           origin-python-version: '3.9'
+          pull-request-change-detection: 'true'
           testing-type: integration
         - ansible-core-version: stable-2.13
           collection-root: .internal/ansible/ansible_collections/internal/test
@@ -111,6 +114,7 @@ jobs:
         git-checkout-ref: ${{ matrix.git-checkout-ref }}
         origin-python-version: ${{ matrix.origin-python-version }}
         pre-test-cmd: ${{ matrix.pre-test-cmd }}
+        pull-request-change-detection: ${{ matrix.pull-request-change-detection || 'false' }}
         target: ${{ matrix.target }}
         target-python-version: ${{ matrix.target-python-version }}
         testing-type: ${{ matrix.testing-type }}

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -36,8 +36,6 @@ jobs:
         - ''
         pre-test-cmd:
         - ''
-        pull-request-change-detection:
-        - ''
         target:
         - ''
         target-python-version:
@@ -72,7 +70,6 @@ jobs:
           collection-root: .internal/ansible/ansible_collections/internal/test
           collection-src-directory: ./.tmp-action-checkout
           origin-python-version: '3.9'
-          pull-request-change-detection: 'true'
           testing-type: integration
         - ansible-core-version: stable-2.13
           collection-root: .internal/ansible/ansible_collections/internal/test
@@ -114,8 +111,6 @@ jobs:
         git-checkout-ref: ${{ matrix.git-checkout-ref }}
         origin-python-version: ${{ matrix.origin-python-version }}
         pre-test-cmd: ${{ matrix.pre-test-cmd }}
-        pull-request-change-detection: >-
-          ${{ matrix.pull-request-change-detection || 'false' }}
         target: ${{ matrix.target }}
         target-python-version: ${{ matrix.target-python-version }}
         testing-type: ${{ matrix.testing-type }}

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -114,7 +114,8 @@ jobs:
         git-checkout-ref: ${{ matrix.git-checkout-ref }}
         origin-python-version: ${{ matrix.origin-python-version }}
         pre-test-cmd: ${{ matrix.pre-test-cmd }}
-        pull-request-change-detection: ${{ matrix.pull-request-change-detection || 'false' }}
+        pull-request-change-detection: >-
+          ${{ matrix.pull-request-change-detection || 'false' }}
         target: ${{ matrix.target }}
         target-python-version: ${{ matrix.target-python-version }}
         testing-type: ${{ matrix.testing-type }}

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -36,6 +36,8 @@ jobs:
         - ''
         pre-test-cmd:
         - ''
+        pull-request-change-detection:
+        - ''
         target:
         - ''
         target-python-version:
@@ -68,8 +70,10 @@ jobs:
           testing-type: units
         - ansible-core-version: stable-2.13
           collection-root: .internal/ansible/ansible_collections/internal/test
-          collection-src-directory: ./.tmp-action-checkout
+          # NOTE: A missing `collection-src-directory` input causes
+          # NOTE: fetching the repo from GitHub.
           origin-python-version: '3.9'
+          pull-request-change-detection: 'true'
           testing-type: integration
         - ansible-core-version: stable-2.13
           collection-root: .internal/ansible/ansible_collections/internal/test
@@ -111,6 +115,8 @@ jobs:
         git-checkout-ref: ${{ matrix.git-checkout-ref }}
         origin-python-version: ${{ matrix.origin-python-version }}
         pre-test-cmd: ${{ matrix.pre-test-cmd }}
+        pull-request-change-detection: >-
+          ${{ matrix.pull-request-change-detection || 'false' }}
         target: ${{ matrix.target }}
         target-python-version: ${{ matrix.target-python-version }}
         testing-type: ${{ matrix.testing-type }}

--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ Extra command to invoke before ansible-test **(OPTIONAL)**
 Whether to use change detection for pull requests. If set to `true`, will
 use change detection to determine changed files against the target branch,
 and will not upload code coverage results. If the invocation is not from a
-pull request, this option is ignored. **(DEFAULT: `false`)**
+pull request, this option is ignored. Note that this requires
+`collection-src-directory` to be empty or something ending with
+`ansible_collections/{namespace}/{name}`. **(DEFAULT: `false`)**
 
 
 ### `python-version`

--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ version supported by the given `ansible-core-version` **(DEFAULT: `auto`)**
 Extra command to invoke before ansible-test **(OPTIONAL)**
 
 
+### `pull-request-change-detection`
+
+Whether to use change detection for pull requests. If set to `true`, will
+use change detection to determine changed files against the target branch,
+and will not upload code coverage results. If the invocation is not from a
+pull request, this option is ignored. **(DEFAULT: `false`)**
+
+
 ### `python-version`
 
 **(DEPRECATED)** Use `origin-python-version` instead.

--- a/action.yml
+++ b/action.yml
@@ -313,8 +313,23 @@ runs:
       set_output('namespace', coll_ns)
 
       set_output('fqcn', f'{coll_ns}.{coll_name}')
-      set_output('collection-namespace-path', f'ansible_collections/{coll_ns}')
-      set_output('checkout-path', f'ansible_collections/{coll_ns}/{coll_name}')
+
+      cwd = os.getcwd()
+      wanted_path = f'ansible_collections{os.sep}{coll_ns}{os.sep}{coll_name}'
+      if cwd.endswith(wanted_path):
+          set_output('copy-to-checkout-path', 'false')
+          set_output(
+              'collection-namespace-path',
+              os.path.normpath(os.path.join(cwd, '..')))
+          set_output('checkout-path', cwd)
+      else:
+          set_output('copy-to-checkout-path', 'true')
+          set_output(
+              'collection-namespace-path',
+              os.path.join('ansible_collections', coll_ns))
+          set_output(
+              'checkout-path',
+              os.path.join('ansible_collections', coll_ns, coll_name))
     shell: python
     working-directory: >-
       ${{
@@ -330,12 +345,16 @@ runs:
       }}
 
   - name: Log the next step action
+    if: >-
+      ${{ fromJSON(steps.collection-metadata.outputs.copy-to-checkout-path) }}
     run: >-
       echo ▷ ${{ inputs.collection-src-directory && 'Copy' || 'Move' }}
       "'${{ steps.collection-metadata.outputs.fqcn }}'"
       collection to ${{ steps.collection-metadata.outputs.checkout-path }}...
     shell: bash
   - name: Move the collection to the proper path
+    if: >-
+      ${{ fromJSON(steps.collection-metadata.outputs.copy-to-checkout-path) }}
     run: >-
       set -x
       ;

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
       use change detection to determine changed files against the target
       branch, and will not upload code coverage results. If the invocation is
       not from a pull request, this option is ignored.
-    default: false
+    default: 'false'
   python-version:
     description: >-
       **(DEPRECATED)** Use `origin-python-version` instead. This is only kept

--- a/action.yml
+++ b/action.yml
@@ -271,15 +271,15 @@ runs:
       # Create a branch for the current HEAD, which happens to be a merge commit
       git checkout -b __action_branch_name
 
-      # Check out the target branch and name it
-      git checkout -b ${{
+      # Name the target branch
+      git branch ${{
         github.event.pull_request.base.ref
       }} --track origin/${{
         github.event.pull_request.base.ref
       }}
 
-      # Check out the merge commit
-      git checkout __action_branch_name
+      # Show branch information
+      git branch -vv
     shell: bash
     working-directory: >-
       .tmp-ansible-collection-checkout

--- a/action.yml
+++ b/action.yml
@@ -302,8 +302,20 @@ runs:
           with OUTPUTS_FILE_PATH.open(FILE_APPEND_MODE) as outputs_file:
               outputs_file.writelines(f'{name}={value}{os.linesep}')
 
+      directory = "${{
+        format(
+          '{0}/{1}',
+          (
+            inputs.collection-src-directory
+            && inputs.collection-src-directory
+            || '.tmp-ansible-collection-checkout'
+          ),
+          inputs.collection-root
+        )
+      }}"
+
       COLLECTION_META_FILE = 'galaxy.yml'
-      with open(COLLECTION_META_FILE) as galaxy_yml:
+      with open(os.path.join(directory, COLLECTION_META_FILE)) as galaxy_yml:
           collection_meta = yaml.load(galaxy_yml)
 
       coll_name = collection_meta['name']
@@ -314,14 +326,13 @@ runs:
 
       set_output('fqcn', f'{coll_ns}.{coll_name}')
 
-      cwd = os.getcwd()
       wanted_path = f'ansible_collections{os.sep}{coll_ns}{os.sep}{coll_name}'
-      if cwd.endswith(wanted_path):
+      if directory.endswith(wanted_path):
           set_output('copy-to-checkout-path', 'false')
           set_output(
               'collection-namespace-path',
-              os.path.normpath(os.path.join(cwd, '..')))
-          set_output('checkout-path', cwd)
+              os.path.normpath(os.path.join(directory, '..')))
+          set_output('checkout-path', directory)
       else:
           set_output('copy-to-checkout-path', 'true')
           set_output(
@@ -331,18 +342,6 @@ runs:
               'checkout-path',
               os.path.join('ansible_collections', coll_ns, coll_name))
     shell: python
-    working-directory: >-
-      ${{
-        format(
-          '{0}/{1}',
-          (
-            inputs.collection-src-directory
-            && inputs.collection-src-directory
-            || '.tmp-ansible-collection-checkout'
-          ),
-          inputs.collection-root
-        )
-      }}
 
   - name: Log the next step action
     if: >-

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,9 @@ inputs:
       Whether to use change detection for pull requests. If set to `true`, will
       use change detection to determine changed files against the target
       branch, and will not upload code coverage results. If the invocation is
-      not from a pull request, this option is ignored.
+      not from a pull request, this option is ignored. Note that this requires
+      `collection-src-directory` to be empty or something ending with
+      `ansible_collections/{namespace}/{name}`.
     default: 'false'
   python-version:
     description: >-

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,13 @@ inputs:
     default: auto
   pre-test-cmd:
     description: Extra command to invoke before ansible-test
+  pull-request-change-detection:
+    description: >-
+      Whether to use change detection for pull requests. If set to `true`, will
+      use change detection to determine changed files against the target
+      branch, and will not upload code coverage results. If the invocation is
+      not from a pull request, this option is ignored.
+    default: 'false'
   python-version:
     description: >-
       **(DEPRECATED)** Use `origin-python-version` instead. This is only kept
@@ -192,6 +199,44 @@ runs:
     shell: bash
 
   - name: Log the next step action
+    run: echo ▷ Figuring out change detection and coverage
+    shell: bash
+  - name: Determine change detection and coverage
+    id: compute-change-detection-coverage
+    run: |
+      # Compute whether to use change detection and coverage
+      import os
+      import pathlib
+      import sys
+
+      FILE_APPEND_MODE = 'a'
+      OUTPUTS_FILE_PATH = pathlib.Path(os.environ['GITHUB_OUTPUT'])
+
+      def set_output(name, value):
+          with OUTPUTS_FILE_PATH.open(FILE_APPEND_MODE) as outputs_file:
+              outputs_file.writelines(f'{name}={value}{os.linesep}')
+
+      # Input from GHA
+      pull_request_change_detection = '${{
+        inputs.pull-request-change-detection
+      }}'
+      pull_request_branch = '${{ github.event.pull_request.base.ref || '' }}'
+
+      # Compute coverage and change detection arguments
+      coverage_arg = '--coverage'
+      change_detection_arg = ''
+      if pull_request_branch and pull_request_change_detection == 'true':
+          coverage_arg = ''
+          change_detection_arg = (
+              f'--changed --base-branch {pull_request_branch}'
+          )
+
+      # Set computed coverage-arg and change-detection-arg
+      set_output('coverage-arg', coverage_arg)
+      set_output('change-detection-arg', change_detection_arg)
+    shell: python
+
+  - name: Log the next step action
     if: >-
       !inputs.collection-src-directory
     run: >-
@@ -205,6 +250,39 @@ runs:
       path: .tmp-ansible-collection-checkout
       persist-credentials: false
       ref: ${{ inputs.git-checkout-ref }}
+      fetch-depth: >-
+        ${{
+          steps.compute-change-detection-coverage.outputs.change-detection-arg
+          && '0' || '1'
+        }}
+
+  - name: Log the next step action
+    if: >-
+      !inputs.collection-src-directory
+      && steps.compute-change-detection-coverage.outputs.change-detection-arg
+    run: >-
+      echo ▷ Create branches for change detection
+    shell: bash
+  - name: Create branches for change detection
+    if: >-
+      !inputs.collection-src-directory
+      && steps.compute-change-detection-coverage.outputs.change-detection-arg
+    run: |
+      # Create a branch for the current HEAD, which happens to be a merge commit
+      git checkout -b __action_branch_name
+
+      # Check out the target branch and name it
+      git checkout -b ${{
+        github.event.pull_request.base.ref
+      }} --track origin/${{
+        github.event.pull_request.base.ref
+      }}
+
+      # Check out the merge commit
+      git checkout __action_branch_name
+    shell: bash
+    working-directory: >-
+      .tmp-ansible-collection-checkout
 
   - name: Log the next step action
     run: >-
@@ -358,7 +436,8 @@ runs:
       ;
       ~/.local/bin/ansible-test ${{ inputs.testing-type }}
       -v --color
-      --coverage
+      ${{ steps.compute-change-detection-coverage.outputs.coverage-arg }}
+      ${{ steps.compute-change-detection-coverage.outputs.change-detection-arg }}
       ${{
           inputs.testing-type == 'sanity'
           && '--junit'
@@ -408,10 +487,12 @@ runs:
     working-directory: ${{ steps.collection-metadata.outputs.checkout-path }}
 
   - name: Log the next step action
+    if: steps.compute-change-detection-coverage.outputs.coverage-arg != ''
     run: >-
       echo ▷ Generating a coverage report...
     shell: bash
   - name: Generate coverage report
+    if: steps.compute-change-detection-coverage.outputs.coverage-arg != ''
     run: >-
       set -x
       ;
@@ -425,6 +506,7 @@ runs:
     working-directory: ${{ steps.collection-metadata.outputs.checkout-path }}
 
   - name: Log the next step action
+    if: steps.compute-change-detection-coverage.outputs.coverage-arg != ''
     run: >-
       echo ▷ Sending the coverage data over to
       https://codecov.io/gh/${{ github.repository }}...
@@ -432,6 +514,7 @@ runs:
   - name: >-
       Send the coverage data over to
       https://codecov.io/gh/${{ github.repository }}
+    if: steps.compute-change-detection-coverage.outputs.coverage-arg != ''
     uses: codecov/codecov-action@v3
     with:
       files: >-

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
       use change detection to determine changed files against the target
       branch, and will not upload code coverage results. If the invocation is
       not from a pull request, this option is ignored.
-    default: 'false'
+    default: false
   python-version:
     description: >-
       **(DEPRECATED)** Use `origin-python-version` instead. This is only kept


### PR DESCRIPTION
Test PR: https://github.com/felixfontein/ansible-playground/pull/4

This is necessary to make https://github.com/ansible-collections/community.crypto/pull/520 bearable (running all integration tests needs 20-30 minutes), and to make a similar thing work for community.general and other larger collections where you usually don't want to run *everything* in CI.

(Not sending code coverage in this case is important since not all tests are run.)

The tricky part here is using ansible-test's change detection since it expects the current commit to be HEAD of a branch, and it expects the branch it is branched from to be around. GitHub's checkout action provides neither, but in the case of pull requests we have the merge commit checked out. By passing `fetch-depth: 0` to the checkout action, we can get all history, and we also get the branches from the repository where this PR runs in. This allows us to checkout `origin/<target_branch_name>` (usually `main`) as `<target_branch_name>`, and we can create a new branch `__action_branch_name` for the current commit (the merge commit). We then can call `ansible-test` with `--changed --base-branch <target_branch_name>` and let ansible-test handle the change detection.

https://github.com/felixfontein/ansible-playground/actions/runs/3352362049/jobs/5554455066 shows how this works. In the PR's branch one file has been modified (`plugins/connection/dummy.py`), while in the current `main` branch of the collection also another file has been modified (the GHA workflow). So ansible-test should only detect the change in the plugin and not in the workflow (if you naively do a `git diff --name-only origin/<target_branch_name>` you get both files). The relevant lines are:
```
Detected branch __action_branch_name forked from main at commit 2ea3f69b761ca43575e749acc0c0fc79e43fb4e2
Detected changes in 1 file(s).
plugins/connection/dummy.py
Mapping 1 changed file(s) to tests.
```
(Note that the linked run was with a slightly older version of this branch, which included a `git log` statement. That's gone now.)