### PR TITLE
Allow to control code coverage

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -46,6 +46,8 @@ jobs:
         - ''
         testing-type:
         - ''
+        coverage:
+        - auto
         exclude:
         - ansible-core-version: ''
         include:
@@ -54,6 +56,7 @@ jobs:
           testing-type: sanity
           collection-root: .
           collection-src-directory: ./.tmp-action-checkout
+          coverage: auto
           pre-action-cmd: >-
             mv -v
             .internal/ansible/ansible_collections/internal/test/galaxy.yml .
@@ -61,17 +64,20 @@ jobs:
         - ansible-core-version: stable-2.12
           collection-root: .internal/ansible/ansible_collections/internal/test
           collection-src-directory: ./.tmp-action-checkout
+          coverage: never
           origin-python-version: auto
           testing-type: sanity
         - ansible-core-version: devel
           collection-root: .internal/ansible/ansible_collections/internal/test
           collection-src-directory: ./.tmp-action-checkout
+          coverage: always
           origin-python-version: auto
           testing-type: units
         - ansible-core-version: stable-2.13
           collection-root: .internal/ansible/ansible_collections/internal/test
           # NOTE: A missing `collection-src-directory` input causes
           # NOTE: fetching the repo from GitHub.
+          coverage: auto
           origin-python-version: '3.9'
           pull-request-change-detection: 'true'
           testing-type: integration
@@ -79,6 +85,7 @@ jobs:
           collection-root: .internal/ansible/ansible_collections/internal/test
           # NOTE: A missing `collection-src-directory` input causes
           # NOTE: fetching the repo from GitHub.
+          coverage: auto
           origin-python-version: auto
           testing-type: integration
           test-deps: >-
@@ -87,6 +94,7 @@ jobs:
         - ansible-core-version: stable-2.14
           collection-root: .internal/ansible/ansible_collections/internal/test
           collection-src-directory: ./.tmp-action-checkout
+          coverage: auto
           origin-python-version: >-
             3.10
           testing-type: integration
@@ -111,6 +119,7 @@ jobs:
         ansible-core-version: ${{ matrix.ansible-core-version }}
         collection-root: ${{ matrix.collection-root }}
         collection-src-directory: ${{ matrix.collection-src-directory }}
+        coverage: ${{ matrix.coverage }}
         docker-image: ${{ matrix.docker-image }}
         git-checkout-ref: ${{ matrix.git-checkout-ref }}
         origin-python-version: ${{ matrix.origin-python-version }}

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ repository if set, also this action will not attempt to mutate
 its contents)**
 
 
+### `coverage`
+
+Whether to collect and upload coverage information. Can be set to
+`always`, `never`, and `auto`. The value `auto` will upload coverage
+information except when `pull-request-change-detection` is set to `true`
+and the action is called from a Pull Request. **(DEFAULT: `auto`)**
+
+
 ### `docker-image`
 
 A container image spawned by `ansible-test` **(OPTIONAL)**

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,13 @@ inputs:
       A pre-checked out collection directory that's already on disk,
       substitutes getting the source from the remote Git repository if
       set. This action will not attempt to mutate its contents
+  coverage:
+    description: >-
+      Whether to collect and upload coverage information. Can be set to
+      `always`, `never`, and `auto`. The value `auto` will upload coverage
+      information except when `pull-request-change-detection` is set to `true`
+      and the action is called from a Pull Request.
+    default: auto
   docker-image:
     description: Docker image used by ansible-test
   git-checkout-ref:
@@ -226,12 +233,22 @@ runs:
         inputs.pull-request-change-detection
       }}')
       pull_request_branch = '${{ github.event.pull_request.base.ref || '' }}'
+      coverage = '${{ inputs.coverage }}'
+
+      # Validate GHA inputs
+      if coverage not in ('always', 'never', 'auto'):
+          print(
+              '::error ::`coverage` must have one of the values `always`,'
+              f' `never`, or `auto`.  The current value is `{coverage}`.'
+          )
+          sys.exit(1)
 
       # Compute coverage and change detection arguments
-      coverage_arg = '--coverage'
+      coverage_arg = '' if coverage == 'never' else '--coverage'
       change_detection_arg = ''
       if pull_request_branch and pull_request_change_detection:
-          coverage_arg = ''
+          if coverage == 'auto':
+              coverage_arg = ''
           change_detection_arg = (
               f'--changed --base-branch {pull_request_branch}'
           )

--- a/action.yml
+++ b/action.yml
@@ -236,7 +236,7 @@ runs:
       coverage = '${{ inputs.coverage }}'
 
       # Validate GHA inputs
-      if coverage not in ('always', 'never', 'auto'):
+      if coverage not in {'always', 'never', 'auto'}:
           print(
               '::error ::`coverage` must have one of the values `always`,'
               f' `never`, or `auto`.  The current value is `{coverage}`.'


### PR DESCRIPTION
~~Contains #49. Will rebase once that is merged.~~ (That is now done.)

Provides a new option `coverage` with values `always`, `never`, and `auto`. The behavior for `auto` is to not send code coverage when `pull-request-change-detection=true` and the action is called from a PR; this can be adjusted later (ref: https://github.com/ansible-community/ansible-test-gh-action/pull/46#discussion_r1012371346, https://github.com/ansible-community/ansible-test-gh-action/pull/46#issuecomment-1313997546).