### PR TITLE
Use Python 3.8 instead of 3.6 as environment Python version

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -50,7 +50,7 @@ jobs:
         - ansible-core-version: ''
         include:
         - ansible-core-version: stable-2.11
-          origin-python-version: '3.6'
+          origin-python-version: '3.8'
           testing-type: sanity
           collection-root: .
           collection-src-directory: ./.tmp-action-checkout


### PR DESCRIPTION
Setup Python 3.6 on `ubuntu-latest` no longer works since `ubuntu-latest` == `ubuntu-22.04`. See https://github.com/actions/setup-python/issues/544.