### PR TITLE
Allow to specify which sanity tests to run / skip / enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,21 @@ The [`python-path` output value][`python-path`] of the [setup-python] action
 The actual value of `origin-python-version` passed to the [setup-python] action
 
 
+### `sanity-tests`
+
+Comma-separated list of sanity tests to run. If not present, all applicable tests are run.
+
+
+### `sanity-skip-tests`
+
+Comma-separated list of sanity tests to skip.
+
+
+### `sanity-allow-disabled`
+
+Allow sanity tests to run which are disabled by default.
+
+
 ## Related community projects
 
 Check out the [Data-Bene/ansible-test-versions-gh-action] to explore

--- a/README.md
+++ b/README.md
@@ -226,7 +226,8 @@ Comma-separated list of sanity tests to skip.
 
 ### `sanity-allow-disabled`
 
-Allow sanity tests to run which are disabled by default.
+Allow running sanity tests that are disabled by default.
+**(DEFAULT: `false`)**
 
 
 ## Related community projects

--- a/action.yml
+++ b/action.yml
@@ -85,6 +85,15 @@ inputs:
     deprecationMessage: >-
       Replace `python-version` with `origin-python-version`.
       It is scheduled to be removed in version 3 of this action.
+  sanity-tests:
+    description: >-
+      Comma-separated list of sanity tests to run.
+      If not present, all applicable tests are run.
+  sanity-skip-tests:
+    description: Comma-separated list of sanity tests to skip.
+  sanity-allow-disabled:
+    description: Allow sanity tests to run which are disabled by default.
+    default: 'false'
   target:
     description: ansible-test TARGET
   target-python-version:
@@ -250,6 +259,9 @@ runs:
       GHA_PULL_REQUEST_BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
       GHA_PULL_REQUEST_CHANGE_DETECTION: >-
         ${{ inputs.pull-request-change-detection }}
+      GHA_SANITY_TESTS: ${{ inputs.sanity-tests }}
+      GHA_SANITY_SKIP_TESTS: ${{ inputs.sanity-skip-tests }}
+      GHA_SANITY_ALLOW_DISABLED: ${{ inputs.sanity-allow-disabled }}
       GHA_TARGET: ${{ inputs.target }}
       GHA_TARGET_PYTHON_VERSION: ${{ inputs.target-python-version }}
       GHA_TESTING_TYPE: ${{ inputs.testing-type }}
@@ -288,6 +300,11 @@ runs:
       gha_pull_request_change_detection = json.loads(
           os.environ['GHA_PULL_REQUEST_CHANGE_DETECTION']
       )
+      gha_sanity_tests = os.environ['GHA_SANITY_TESTS']
+      gha_sanity_skip_tests = os.environ['GHA_SANITY_SKIP_TESTS']
+      gha_sanity_allow_disabled = json.loads(
+          os.environ['GHA_SANITY_ALLOW_DISABLED']
+      )
       gha_target = os.environ['GHA_TARGET']
       gha_target_python_version = os.environ['GHA_TARGET_PYTHON_VERSION']
       gha_testing_type = os.environ['GHA_TESTING_TYPE']
@@ -325,6 +342,21 @@ runs:
 
       if gha_testing_type == 'sanity':
           command.append('--junit')
+
+          if gha_sanity_tests:
+              for test in gha_sanity_tests.split(','):
+                  command.extend([
+                      '--test',
+                      test.strip(),
+                  ])
+          if gha_sanity_skip_tests:
+              for test in gha_sanity_skip_tests.split(','):
+                  command.extend([
+                      '--skip-test',
+                      test.strip(),
+                  ])
+          if gha_sanity_allow_disabled:
+              command.append('--allow-disabled')
 
       if gha_testing_type == 'integration':
           if gha_integration_retry_on_error:

--- a/action.yml
+++ b/action.yml
@@ -304,7 +304,7 @@ runs:
       gha_sanity_skip_tests = os.environ['GHA_SANITY_SKIP_TESTS']
       gha_sanity_allow_disabled = json.loads(
           os.environ['GHA_SANITY_ALLOW_DISABLED']
-      )
+      ) is True
       gha_target = os.environ['GHA_TARGET']
       gha_target_python_version = os.environ['GHA_TARGET_PYTHON_VERSION']
       gha_testing_type = os.environ['GHA_TESTING_TYPE']


### PR DESCRIPTION
Includes a refactor to generate all ansible-test parameters with Python code.

Skipping specific sanity tests is needed when these totally break due to bugs, see for example https://github.com/ansible/ansible/pull/82574. There is no way to ignore the failure fixed by that PR with `ignore.txt`.