### PR TITLE
Add Python versions for ansible-core 2.16 to 2.19

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -199,6 +199,10 @@ runs:
               'stable-2.13': (3, 10),
               'stable-2.14': (3, 11),
               'stable-2.15': (3, 11),
+              'stable-2.16': (3, 12),
+              'stable-2.17': (3, 12),
+              'stable-2.18': (3, 13),
+              'stable-2.19': (3, 13),
           }
           python_version_fallback_for_devel = max(
               set(python_version_map.values()),


### PR DESCRIPTION
Right now the list stops for 2.15, and thus Python 3.11 is used for all newer ansible-core versions. Since ansible-core 2.20 will drop support for Python 3.11 this will sooner or later become a problem.