### PR TITLE
fix: do not ignore GHA_CONTAINER_NETWORK in unit test mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -377,6 +377,8 @@ runs:
               command.append('--continue-on-error')
           if gha_integration_diff:
               command.append('--diff')
+
+      if gha_testing_type == 'integration' or gha_testing_type == 'unit':
           if gha_container_network != '':
               command.append(f"--docker-network={gha_container_network}")
 

--- a/action.yml
+++ b/action.yml
@@ -378,7 +378,7 @@ runs:
           if gha_integration_diff:
               command.append('--diff')
 
-      if gha_testing_type == 'integration' or gha_testing_type == 'unit':
+      if gha_testing_type in {'integration', 'unit'}:
           if gha_container_network != '':
               command.append(f"--docker-network={gha_container_network}")
 


### PR DESCRIPTION
I am writing unit tests that require external api access and the default docker container testing image has no network access

`GHA_CONTAINER_NETWORK` is ignored in `unit` mode

I can run the tests successfully locally with `ansible-test units --docker --docker-network host` 