### PR TITLE
🐛 Fix broken bash script for exportable path lookup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -651,7 +651,7 @@ runs:
       ;
       echo -n "paths=" | tee -a "${GITHUB_OUTPUT}"
       ;
-      $(
+      (
       (
       find '${{
         steps.collection-metadata.outputs.checkout-path
@@ -690,7 +690,7 @@ runs:
       ;
       echo -n "paths=" | tee -a "${GITHUB_OUTPUT}"
       ;
-      $(
+      (
       (
       find '${{
         steps.collection-metadata.outputs.checkout-path


### PR DESCRIPTION
This bug was introduced in ef2e123ff0cd0ebd52bef2b3bc55a42628c308d4
and 23c6eddb5fc02fd1e5d64c294af8245e70d2ffc7.

The problem was having `$(...) | tee ...` in the steps that were
performing path lookups. The parentheses that were supposed to group
commands were mistakenly trying to evaluate the output of the
converted `find` output.

This patch makes it `(...) | tee ...` as it should've been originally.