### PR TITLE
Upload coverage XML files as job artifacts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -791,4 +791,24 @@ runs:
       cat code-coverage-results.md >> "${GITHUB_STEP_SUMMARY}"
     shell: bash
 
+  - name: Log the next step action
+    if: >-
+      always()
+      && steps.exportable-coverage-files.outputs.paths != ''
+    run: >-
+      echo ▷ Uploading coverage XML files as artifacts...
+    shell: bash
+  - name: Upload coverage XML files
+    if: >-
+      always()
+      && steps.exportable-coverage-files.outputs.paths != ''
+    uses: actions/upload-artifact@v4
+    with:
+      name: >-
+        coverage-${{ inputs.testing-type }}-${{
+          steps.compute-origin-python-version.outputs.origin-python-version
+        }}
+      path: ${{ steps.exportable-coverage-files.outputs.paths }}
+      if-no-files-found: ignore
+
 ...


### PR DESCRIPTION
## Summary
- Adds `upload-artifact` step to attach coverage XML files to GitHub Actions jobs
- Coverage files are uploaded with naming pattern: `coverage-{testing-type}-{python-version}`
- Uses `always()` condition so artifacts are uploaded even if tests fail
- Follows existing action pattern with logging step before action

## Test plan
- [ ] Verify coverage artifacts are uploaded when coverage is generated
- [ ] Check artifact naming matches expected pattern
- [ ] Confirm artifacts include correct coverage XML files
- [ ] Validate upload works even when tests fail (if coverage was generated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)