### PR TITLE
Chore: Pin actions to specific SHA-1 commit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -233,7 +233,9 @@ runs:
       Set controller Python to
       ${{ steps.compute-origin-python-version.outputs.origin-python-version }}
     id: setup-python
-    uses: actions/setup-python@v7
+    # yamllint disable rule:line-length
+    uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+    # yamllint enable rule:line-length
     with:
       python-version: >-
         ${{
@@ -432,7 +434,7 @@ runs:
   - name: Check out the collection
     if: >-
       !inputs.collection-src-directory
-    uses: actions/checkout@v7
+    uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
     with:
       path: .tmp-ansible-collection-checkout
       persist-credentials: false
@@ -734,7 +736,9 @@ runs:
       Send the coverage data over to
       https://codecov.io/gh/${{ github.repository }}
     if: steps.exportable-coverage-files.outputs.paths != ''
-    uses: codecov/codecov-action@v7.0.0
+    # yamllint disable rule:line-length
+    uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
+    # yamllint enable rule:line-length
     with:
       files: ${{ steps.exportable-coverage-files.outputs.paths }}
       flags: ${{ inputs.testing-type }}
@@ -745,7 +749,7 @@ runs:
     if: >-
       always()
       && steps.exportable-junit-files.outputs.paths != ''
-    uses: test-summary/action@v2
+    uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
     with:
       # NOTE: The path is borrowed from
       # https://github.com/ansible/ansible/blob/71adb02/.azure-pipelines/scripts/process-results.sh#L6-L10
@@ -775,7 +779,9 @@ runs:
     shell: bash
   - name: Produce markdown test summary from Cobertura XML
     if: steps.coverage-files.outputs.present == 'true'
-    uses: irongut/CodeCoverageSummary@v1.3.0
+    # yamllint disable rule:line-length
+    uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95  # v1.3.0
+    # yamllint enable rule:line-length
     with:
       badge: true
       filename: >-


### PR DESCRIPTION
Fixes #120 
Related to ansible-collections/partner-certification-checker/issues/92

This can close PR #121 started by @caliban0, I updated his work with updated SHAs and addressed yamllint issues raised by pre-commit.
