### PR TITLE
fix: trim trailing newline from pre-test-cmd input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -617,7 +617,7 @@ runs:
     run: >-
       ${{
           inputs.pre-test-cmd
-          && format('set -x; {0}; set +x', inputs.pre-test-cmd | trim)
+          && format('set -x; {0}; set +x', trim(inputs.pre-test-cmd))
           || '>&2 echo Skipping running the pre test command...'
       }}
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -617,7 +617,7 @@ runs:
     run: >-
       ${{
           inputs.pre-test-cmd
-          && format('set -x; {0}; set +x', inputs.pre-test-cmd)
+          && format('set -x; {0}; set +x', inputs.pre-test-cmd | trim)
           || '>&2 echo Skipping running the pre test command...'
       }}
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -614,12 +614,10 @@ runs:
   - name: Run a pre-test command
     # if: inputs.pre-test-cmd
     # run: ${{ inputs.pre-test-cmd }}
-    run: >-
-      ${{
-          inputs.pre-test-cmd
-          && format('set -x; {0}; set +x', trim(inputs.pre-test-cmd))
-          || '>&2 echo Skipping running the pre test command...'
-      }}
+    run: |-
+      ${{ inputs.pre-test-cmd && 'set -x' || '>&2 echo Skipping running the pre test command...' }}
+      ${{ inputs.pre-test-cmd }}
+      ${{ inputs.pre-test-cmd && 'set +x' || '' }}
     shell: bash
     working-directory: ${{ steps.collection-metadata.outputs.checkout-path }}
 

--- a/action.yml
+++ b/action.yml
@@ -615,7 +615,10 @@ runs:
     # if: inputs.pre-test-cmd
     # run: ${{ inputs.pre-test-cmd }}
     run: |-
-      ${{ inputs.pre-test-cmd && 'set -x' || '>&2 echo Skipping running the pre test command...' }}
+      ${{ inputs.pre-test-cmd
+          && 'set -x'
+          || '>&2 echo Skipping the pre test cmd...'
+      }}
       ${{ inputs.pre-test-cmd }}
       ${{ inputs.pre-test-cmd && 'set +x' || '' }}
     shell: bash


### PR DESCRIPTION
## Summary
- When `pre-test-cmd` is provided as a YAML block scalar (`|`), it includes a trailing newline
- The `format()` call produced a shell script with `; set +x` on its own line, causing a bash syntax error (`syntax error near unexpected token ';'`)
- Neither `trim()` (function) nor `| trim` (filter) are available in composite action expressions — they only work in workflow files
- Fix by removing `format()` entirely and splitting `set -x` / command / `set +x` onto separate lines using a literal block scalar (`|-`), where a trailing newline becomes a harmless blank line in bash

## Real-world failure
https://github.com/ansible-collections/amazon.aws/actions/runs/30841816931/job/91780607096?pr=3053

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Test with a `pre-test-cmd` using block scalar (`|`) syntax
- [ ] Test with a `pre-test-cmd` using inline string syntax (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)